### PR TITLE
Fix typo in Swedish README.

### DIFF
--- a/locales/README.sv_SE.md
+++ b/locales/README.sv_SE.md
@@ -11,7 +11,7 @@
 
 ## Om
 
-Rocky Linux är ett Community Enterprise Operativ system designat att vara 100% bugg-för-bugg-kompatibelt med Enterprise Linux, nu när CentOS har ändrat inriktning.
+Rocky Linux är ett Community Enterprise Operativsystem designat att vara 100% bugg-för-bugg-kompatibelt med Enterprise Linux, nu när CentOS har ändrat inriktning.
 
 ## Vanliga frågor och svar
 > **F:** Vad menar ni med att, "CentOS har ändrat inriktning"


### PR DESCRIPTION
It seems like the term Operativ System had a space too much thus the term is as we swedes would say "särskriven".
This might not be a problem but it is not grammatically correct for the Swedish language.